### PR TITLE
Removed "GIST_GEOMETRY_OPS" from spatial index creation

### DIFF
--- a/geoalchemy/postgis.py
+++ b/geoalchemy/postgis.py
@@ -128,7 +128,7 @@ class PGSpatialDialect(SpatialDialect):
                                                     column.type.name, 
                                                     column.type.dimension)]).execution_options(autocommit=True))
         if column.type.spatial_index:
-            bind.execute("CREATE INDEX \"idx_%s_%s\" ON \"%s\".\"%s\" USING GIST (%s GIST_GEOMETRY_OPS)" % 
+            bind.execute("CREATE INDEX \"idx_%s_%s\" ON \"%s\".\"%s\" USING GIST (%s)" % 
                             (table.name, column.name, (table.schema or 'public'), table.name, column.name))
             
         if not column.nullable:


### PR DESCRIPTION
GIST_GEOMETRY_OPS is already default for postgis 1.x and not compatible with postgis 2.x. Removing from index creation will allow compatibility with both.
