### PR TITLE
Null comparison and not equal operator

### DIFF
--- a/geoalchemy/base.py
+++ b/geoalchemy/base.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm.properties import ColumnProperty
-from sqlalchemy.sql import expression
+from sqlalchemy.sql import expression, not_
 from sqlalchemy.sql.expression import ColumnClause, literal
 from sqlalchemy.types import UserDefinedType
 from sqlalchemy.ext.compiler import compiles
@@ -254,3 +254,7 @@ class SpatialComparator(ColumnProperty.ColumnComparator):
             return self.op("IS")(None)
         return functions.equals(self, other)
     
+    def __ne__(self, other):
+        if other is None:
+            return self.op("IS NOT")(None)
+        return not_(functions.equals(self, other))

--- a/geoalchemy/tests/test_postgis.py
+++ b/geoalchemy/tests/test_postgis.py
@@ -248,6 +248,11 @@ class TestGeometry(TestCase):
         r3 = session.query(Road).filter(Road.road_geom == r1.road_geom).one()
         ok_(r1 is r2 is r3)
 
+    def test_ne(self):
+        r1 = session.query(Road).filter(Road.road_name=='Graeme Ave').one()
+        r2 = session.query(Road).filter(Road.road_geom == 'LINESTRING(-88.5477708726115 42.6988853949045,-88.6096339299363 42.9697452675159,-88.6029460318471 43.0884554585987,-88.5912422101911 43.187101955414)').one()
+        ok_(r2 not in session.query(Road).filter(Road.road_geom != r2.road_geom).all())
+
     def test_length(self):
         r = session.query(Road).filter(Road.road_name=='Graeme Ave').one()
         assert_almost_equal(session.scalar(r.road_geom.length), 0.496071476676014)


### PR DESCRIPTION
- Added functionality to check geometry is Null using '==' syntax
- Added '!=' operator to call 'NOT ST_Equal' and 'IS NOT NULL'
  I've added tests for these two additions, but unfortunately for postgis only, as that is all I have available to test with currently.

Idea came from google groups question from Will Furnass and work around from Tobias. https://groups.google.com/d/topic/geoalchemy/dc1yYfd5zLg/discussion
