### PR TITLE
0.7 release is not pip installable because README.rst is missing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 GeoAlchemy Change Log
 =====================
 
+0.7.1
+-----
+
+* add MANIFEST.in file to include README.rst in source packages. fixes build errors.
+
 0.7
 ---
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.rst
+include RELEASE.txt
+include CHANGES.txt


### PR DESCRIPTION
create MANIFEST.in to include README.rst to sdist packages, which is required in setup.py

also include RELEASE.txt and CHANGES.txt
