### PR TITLE
GeoAlchemy 0.7.1 doesn't work with SQLAlchemy 0.8.0b2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ GeoAlchemy Change Log
 * PostGIS: use the "ST_" versions of the GeomFromWKB, GeomFromText, and
   isValid functions. This changes breaks compatibility with PostGIS < 1.4
   but is a step towards PostGIS 2.0. (#19, #20, @Phacops)
+* Fix incompatibility with SQLAlchemy 0.8.0b2. (#27)
 
 0.7.1
 -----

--- a/geoalchemy/geometry.py
+++ b/geoalchemy/geometry.py
@@ -166,7 +166,7 @@ def compile_column(element, compiler, **kw):
                     % compiler.dialect.name, exc.SAWarning)
             return compiler.process(functions.wkb(element))
         
-    return compiler.visit_column(element) 
+    return compiler.visit_column(element, **kw)
      
             
 def GeometryColumn(*args, **kw):


### PR DESCRIPTION
This has been [reported](https://groups.google.com/forum/#!topic/geoalchemy/vSAlsuhwWfo/discussion) on the mailing list. A [fix](https://gist.github.com/4497133) was found by @zzzeek and I on [Twitter](https://twitter.com/erilem/status/289122470433275904).
