### PR TITLE
Add support for sqlalchemy 0.9

### DIFF
--- a/geoalchemy/base.py
+++ b/geoalchemy/base.py
@@ -1,6 +1,10 @@
 from sqlalchemy.orm.properties import ColumnProperty
 from sqlalchemy.sql import expression, not_
 from sqlalchemy.sql.expression import ColumnClause, literal
+try:
+    from sqlalchemy.sql.functions import Function
+except ImportError:
+    from sqlalchemy.sql.expression import Function  # sqlalchemy < 0.9
 from sqlalchemy.types import UserDefinedType
 from sqlalchemy.ext.compiler import compiles
 
@@ -45,7 +49,7 @@ class SpatialElement(object):
         wkt = self.__get_wkt(session)
         return from_wkt(wkt)["coordinates"]
 
-class WKTSpatialElement(SpatialElement, expression.Function):
+class WKTSpatialElement(SpatialElement, Function):
     """Represents a Geometry value expressed within application code; i.e. in
     the OGC Well Known Text (WKT) format.
     
@@ -61,7 +65,7 @@ class WKTSpatialElement(SpatialElement, expression.Function):
         self.srid = srid
         self.geometry_type = geometry_type
         
-        expression.Function.__init__(self, "")
+        Function.__init__(self, "")
 
     @property
     def geom_wkt(self):
@@ -74,7 +78,7 @@ def __compile_wktspatialelement(element, compiler, **kw):
     
     return compiler.process(function)
 
-class WKBSpatialElement(SpatialElement, expression.Function):
+class WKBSpatialElement(SpatialElement, Function):
     """Represents a Geometry value as expressed in the OGC Well
     Known Binary (WKB) format.
     
@@ -90,7 +94,7 @@ class WKBSpatialElement(SpatialElement, expression.Function):
         self.srid = srid
         self.geometry_type = geometry_type
         
-        expression.Function.__init__(self, "")
+        Function.__init__(self, "")
 
 @compiles(WKBSpatialElement)
 def __compile_wkbspatialelement(element, compiler, **kw):
@@ -104,7 +108,7 @@ def __compile_wkbspatialelement(element, compiler, **kw):
     return compiler.process(function)
 
 
-class DBSpatialElement(SpatialElement, expression.Function):
+class DBSpatialElement(SpatialElement, Function):
     """This class can be used to wrap a geometry returned by a 
     spatial database operation.
     
@@ -117,7 +121,7 @@ class DBSpatialElement(SpatialElement, expression.Function):
     
     def __init__(self, desc):
         self.desc = desc
-        expression.Function.__init__(self, "", desc)
+        Function.__init__(self, "", desc)
 
 @compiles(DBSpatialElement)
 def __compile_dbspatialelement(element, compiler, **kw):
@@ -239,7 +243,7 @@ class RawColumn(ColumnClause):
 def __compile_rawcolumn(rawcolumn, compiler, **kw):
     return compiler.visit_column(rawcolumn.column)
 
-class SpatialComparator(ColumnProperty.ColumnComparator):
+class SpatialComparator(ColumnProperty.Comparator):
     """Intercepts standard Column operators on mapped class attributes
         and overrides their behavior.
         

--- a/geoalchemy/functions.py
+++ b/geoalchemy/functions.py
@@ -1,4 +1,8 @@
-from sqlalchemy.sql.expression import Function, ClauseElement
+try:
+    from sqlalchemy.sql.functions import Function
+except ImportError:
+    from sqlalchemy.sql.expression import Function  # sqlalchemy < 0.9
+from sqlalchemy.sql.expression import ClauseElement
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy import literal
 from sqlalchemy.types import NullType, TypeDecorator


### PR DESCRIPTION
Changes compatible with sqlalchemy 0.6.1+ (even renaming ColumnComparator to Comparator).
